### PR TITLE
remove observer from NSNotification center in dealloc to avoid app crash...

### DIFF
--- a/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
+++ b/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
@@ -45,6 +45,7 @@ static CGFloat minVolume                    = 0.00001f;
 
 - (void)dealloc {
     [self.session removeObserver:self forKeyPath:sessionVolumeKeyPath];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self.volumeView removeFromSuperview];
 }
 


### PR DESCRIPTION
hi i used your class just in a subview and it gets deallocated when removing the subview. when the app later goes into background it calls the selector for AVAudioSessionInterruptionNotification. this results in:
-[__NSDictionaryM audioSessionInterrupted:]: unrecognized selector sent to instance 0x........
libc++abi.dylib: terminate_handler unexpectedly threw an exception

i just added one line to avoid these crashes :) 