### PR TITLE
Don't set AVAudioSession category

### DIFF
--- a/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
+++ b/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
@@ -52,11 +52,6 @@ static CGFloat minVolume                    = 0.00001f;
 - (void)setupSession {
     NSError *error = nil;
     self.session = [AVAudioSession sharedInstance];
-    [self.session setCategory:AVAudioSessionCategoryAmbient withOptions:0 error:&error];
-    if (error) {
-        NSLog(@"%@", error);
-        return;
-    }
     [self.session setActive:YES error:&error];
     if (error) {
         NSLog(@"%@", error);


### PR DESCRIPTION
This doesn't seem to be necessary, and can screw up `AVCaptureSessions` - specifically, subsequent calls to `AVCaptureMovieFileOutput#startRecordingToOutputFileURL`

Fixes #7