### PR TITLE
Handle Media Remote Volume Mute

### DIFF
--- a/JPSVolumeButtonHandler/JPSVolumeButtonHandler.h
+++ b/JPSVolumeButtonHandler/JPSVolumeButtonHandler.h
@@ -18,7 +18,16 @@ typedef void (^JPSVolumeButtonBlock)();
 // A block to run when the volume down button is pressed
 @property (nonatomic, copy) JPSVolumeButtonBlock downBlock;
 
+// A block to run when the volume mute button is pressed
+@property (nonatomic, copy) JPSVolumeButtonBlock muteBlock;
+
 // Returns a button handler with the specified up/down volume button blocks
 + (instancetype)volumeButtonHandlerWithUpBlock:(JPSVolumeButtonBlock)upBlock downBlock:(JPSVolumeButtonBlock)downBlock;
+
+// Returns a button handler with the specified volume up/down/mute blocks
+// volume mute handling is intended to work with a media remote, and may not function correctly with hardware mute
++ (instancetype)volumeButtonHandlerWithUpBlock:(JPSVolumeButtonBlock)upBlock
+                                     downBlock:(JPSVolumeButtonBlock)downBlock
+                                     muteBlock:(JPSVolumeButtonBlock)muteBlock;
 
 @end


### PR DESCRIPTION
Added handling for media remote volume mute. This may not work properly with device hardware mute, and at the very least won’t properly handle the device hardware unmute.