### PR TITLE
Hide ios9 volume popup when first loading

### DIFF
--- a/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
+++ b/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
@@ -36,7 +36,8 @@ static CGFloat minVolume                    = 0.00001f;
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidChangeActive:) name:UIApplicationWillResignActiveNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidChangeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
-
+        
+        [self disableVolumeHUD];
         [self setInitialVolume];
     }
     return self;


### PR DESCRIPTION
Initial fix worked when app was from background, however not when app just started. this fixes it.