### PR TITLE
Allow stopping and starting the volume handling

### DIFF
--- a/JPSVolumeButtonHandler/JPSVolumeButtonHandler.h
+++ b/JPSVolumeButtonHandler/JPSVolumeButtonHandler.h
@@ -18,6 +18,9 @@ typedef void (^JPSVolumeButtonBlock)();
 // A block to run when the volume down button is pressed
 @property (nonatomic, copy) JPSVolumeButtonBlock downBlock;
 
+- (void)startHandler;
+- (void)stopHandler;
+
 // Returns a button handler with the specified up/down volume button blocks
 + (instancetype)volumeButtonHandlerWithUpBlock:(JPSVolumeButtonBlock)upBlock downBlock:(JPSVolumeButtonBlock)downBlock;
 


### PR DESCRIPTION
This makes it easier to only block volume changes temporarily (or in
certain views in the app), without having to destroy and re-create
the handler. This is especially necessary when using autorelase.