### PR TITLE
Allow listening to volume buttons without blocking the changes from occurring

### DIFF
--- a/JPSVolumeButtonHandler/JPSVolumeButtonHandler.h
+++ b/JPSVolumeButtonHandler/JPSVolumeButtonHandler.h
@@ -18,6 +18,9 @@ typedef void (^JPSVolumeButtonBlock)();
 // A block to run when the volume down button is pressed
 @property (nonatomic, copy) JPSVolumeButtonBlock downBlock;
 
+- (void)startHandler;
+- (void)stopHandler;
+
 // Returns a button handler with the specified up/down volume button blocks
 + (instancetype)volumeButtonHandlerWithUpBlock:(JPSVolumeButtonBlock)upBlock downBlock:(JPSVolumeButtonBlock)downBlock;
 

--- a/JPSVolumeButtonHandler/JPSVolumeButtonHandler.h
+++ b/JPSVolumeButtonHandler/JPSVolumeButtonHandler.h
@@ -18,7 +18,7 @@ typedef void (^JPSVolumeButtonBlock)();
 // A block to run when the volume down button is pressed
 @property (nonatomic, copy) JPSVolumeButtonBlock downBlock;
 
-- (void)startHandler;
+- (void)startHandler:(BOOL)disableSystemVolumeHandler;
 - (void)stopHandler;
 
 // Returns a button handler with the specified up/down volume button blocks


### PR DESCRIPTION
For the case where the client simply wants to know whether the user changes
their volume, without having to implement and manage the KVO

Note: This retains the same limitation as that method, where pressing up
while already at the max volume (or down while at 0) will not trigger a callback