### PR TITLE
Always remove volumeView

### DIFF
--- a/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
+++ b/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
@@ -50,8 +50,8 @@ static CGFloat minVolume                    = 0.00001f;
 - (void)dealloc {
     if (_isStarted) {
         [self stopHandler];
-        [self.volumeView removeFromSuperview];
     }
+    [self.volumeView removeFromSuperview];
 }
 
 - (void)startHandler:(BOOL)disableSystemVolumeHandler {


### PR DESCRIPTION
If you stop the handler, and then dealloc the object, the volumeView will remain attached to its superview, preventing the default HUD from showing