### PR TITLE
JPSVolumeButtonHandler Added feature to allow the handler to only res…

### DIFF
--- a/JPSVolumeButtonHandler/JPSVolumeButtonHandler.h
+++ b/JPSVolumeButtonHandler/JPSVolumeButtonHandler.h
@@ -24,6 +24,10 @@ typedef void (^JPSVolumeButtonBlock)();
 - (void)startHandler:(BOOL)disableSystemVolumeHandler;
 - (void)stopHandler;
 
+// A Function to set exactJumpsOnly.  When set to YES, only volume jumps of .0625 call the code blocks.
+// If it doesn't match, the code blocks are not called and setInitialVolume is called
+- (void)useExactJumpsOnly:(BOOL)enabled;
+
 // Returns a button handler with the specified up/down volume button blocks
 + (instancetype)volumeButtonHandlerWithUpBlock:(JPSVolumeButtonBlock)upBlock downBlock:(JPSVolumeButtonBlock)downBlock;
 


### PR DESCRIPTION
…pond to exact button presses, rather than just responding to any change in volume.

1. Basically, our app and another app were having some major interference.  What we do when we received a volume button caused another app to change the volume of the phone, but not by the same amount.  However, because this is a volume change, one button press would trigger another and so on.  This PR adds a new feature, where an app, if they call useExactJumpsOnly:YES, the handler will only respond to jumps that are exactly the 6.25% that actual button presses are (+/- .05% since these are floating point values).

2. I cleaned up the logging a little.