### PR TITLE
Bluetooth Playback fix and ExactJump near min/max fix

### DIFF
--- a/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
+++ b/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
@@ -40,7 +40,7 @@ static CGFloat minVolume                    = 0.00001f;
     
     if (self) {
         _appIsActive = YES;
-        _sessionCategory = AVAudioSessionCategoryPlayAndRecord;
+        _sessionCategory = AVAudioSessionCategoryPlayback;
 
         _volumeView = [[MPVolumeView alloc] initWithFrame:CGRectMake(MAXFLOAT, MAXFLOAT, 0, 0)];
 

--- a/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
+++ b/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
@@ -220,8 +220,11 @@ static CGFloat minVolume                    = 0.00001f;
         CGFloat difference = fabs(newVolume-oldVolume);
 
         JPSLog(@"Old Vol:%f New Vol:%f Difference = %f", (double)oldVolume, (double)newVolume, (double) difference);
-        if (_exactJumpsOnly && (difference > .063 || difference < .062)) {
-            JPSLog(@"Ignoring non-standard Jump of %f, which is not the .0625 a press of the actually volume button would have resulted in.", difference);
+
+        if (_exactJumpsOnly && difference < .062 && (newVolume == 1. || newVolume == 0)) {
+            JPSLog(@"Using a non-standard Jump of %f (%f-%f) which is less than the .0625 because a press of the volume button resulted in hitting min or max volume", difference, oldVolume, newVolume);
+        } else if (_exactJumpsOnly && (difference > .063 || difference < .062)) {
+            JPSLog(@"Ignoring non-standard Jump of %f (%f-%f), which is not the .0625 a press of the actually volume button would have resulted in.", difference, oldVolume, newVolume);
             [self setInitialVolume];
             return;
         }


### PR DESCRIPTION
Fixes #46 We must default to the Playback Category. If you want your app to record, you can simply use the setSessionCatagory: message to set back to PlayAndRecord. But, as it was before this commit, playback is stopped over bluetooth immediately, even if I change it to Playback, it doesn’t start playing again. @samyes and @CallumOz Take note of this change

Fixes an issue with my last PR and the exactJumpsOnly Feature I added
 The feature will now allow jumps to 0 or 1 to allow for working with button presses when the volume is near max/min.

