### PR TITLE
Add the option to customize the audio session category options

### DIFF
--- a/JPSVolumeButtonHandler/JPSVolumeButtonHandler.h
+++ b/JPSVolumeButtonHandler/JPSVolumeButtonHandler.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
 
 typedef void (^JPSVolumeButtonBlock)(void);
 
@@ -20,6 +21,8 @@ typedef void (^JPSVolumeButtonBlock)(void);
 
 // A shared audio session category
 @property (nonatomic, strong) NSString * sessionCategory;
+
+@property (nonatomic, assign) AVAudioSessionCategoryOptions sessionOptions;
 
 - (void)startHandler:(BOOL)disableSystemVolumeHandler;
 - (void)stopHandler;

--- a/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
+++ b/JPSVolumeButtonHandler/JPSVolumeButtonHandler.m
@@ -7,7 +7,6 @@
 //
 
 #import "JPSVolumeButtonHandler.h"
-#import <AVFoundation/AVFoundation.h>
 #import <MediaPlayer/MediaPlayer.h>
 
 // Comment/uncomment out NSLog to enable/disable logging
@@ -41,6 +40,7 @@ static CGFloat minVolume                    = 0.00001f;
     if (self) {
         _appIsActive = YES;
         _sessionCategory = AVAudioSessionCategoryPlayback;
+        _sessionOptions = AVAudioSessionCategoryOptionMixWithOthers;
 
         _volumeView = [[MPVolumeView alloc] initWithFrame:CGRectMake(MAXFLOAT, MAXFLOAT, 0, 0)];
 
@@ -99,7 +99,7 @@ static CGFloat minVolume                    = 0.00001f;
     // this must be done before calling setCategory or else the initial volume is reset
     [self setInitialVolume];
     [self.session setCategory:_sessionCategory
-                  withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                  withOptions:_sessionOptions
                         error:&error];
     if (error) {
         NSLog(@"%@", error);

--- a/README.md
+++ b/README.md
@@ -40,12 +40,20 @@ To enbable/disable the handler:
 [self.volumeButtonHandler stopHandler];
 ```
 
-To change audio session category (by default AVAudioSessionCategoryPlayAndRecord):
+To change audio session category (by default `AVAudioSessionCategoryPlayAndRecord`):
 
 ```objective-c
 // Set category
 self.volumeButtonHandler.sessionCategory = AVAudioSessionCategoryAmbient; 
 ```
+
+To change the audio session category options (by default `AVAudioSessionCategoryOptionMixWithOthers`):
+
+```objective-c
+self.volumeButtonHandler.sessionOptions = AVAudioSessionCategoryOptionAllowBluetooth|AVAudioSessionCategoryOptionMixWithOthers;
+```
+
+Note that not all options are compatible with all category options. See `AVAudioSession` documentation for details.
 
 ## License
 


### PR DESCRIPTION
Our app needed to use different options, but the existing version of this project hard-codes the options. This patch makes those customizable, in the same way that the category is already customizable.