### PR TITLE
SPM (Swift Package Manager) support

### DIFF
--- a/JPSVolumeButtonHandler/include/JPSVolumeButtonHandler.h
+++ b/JPSVolumeButtonHandler/include/JPSVolumeButtonHandler.h
@@ -1,0 +1,1 @@
+../JPSVolumeButtonHandler.h

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.4
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "JPSVolumeButtonHandler",
+    platforms: [.iOS(.v11)],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "JPSVolumeButtonHandler",
+            targets: ["JPSVolumeButtonHandler"]
+        ),
+    ],
+    dependencies: [],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "JPSVolumeButtonHandler",
+            dependencies: [],
+            path: "JPSVolumeButtonHandler/"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # JPSVolumeButtonHandler
 
+`JPSVolumeButtonHandler` provides an easy block interface to hardware volume buttons on iOS devices. Perfect for camera apps! Used in [`JPSImagePickerController`](https://github.com/jpsim/JPSImagePickerController).
+
 Features:
 
 * Run blocks whenever a hardware volume button is pressed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # JPSVolumeButtonHandler
 
-`JPSVolumeButtonHandler` provides an easy block interface to hardware volume buttons on iOS devices. Perfect for camera apps! Used in [`JPSImagePickerController`](https://github.com/jpsim/JPSImagePickerController).
-
 Features:
 
 * Run blocks whenever a hardware volume button is pressed
@@ -13,9 +11,9 @@ Features:
 
 ### Swift Package Manager (SPM)
 
-Add: `https://github.com/nylki/JPSVolumeButtonHandler.git` (`master` branch) to your "Package Dependencies" in XCode.
+Add: `https://github.com/jpsim/JPSVolumeButtonHandler.git` (`master` branch) to your "Package Dependencies" in XCode.
 
-Or add: `.package(url: "https://github.com/nylki/JPSVolumeButtonHandler.git", branch: "master")` to your swift package file.
+Or add: `.package(url: "https://github.com/jpsim/JPSVolumeButtonHandler.git", branch: "master")` to your swift package file.
 
 ### From CocoaPods
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Features:
 
 ## Installation
 
+### Swift Package Manager (SPM)
+
+Add: `https://github.com/nylki/JPSVolumeButtonHandler.git` (`master` branch) to your "Package Dependencies" in XCode.
+
+Or add: `.package(url: "https://github.com/nylki/JPSVolumeButtonHandler.git", branch: "master")` to your swift package file.
+
 ### From CocoaPods
 
 Add `pod 'JPSVolumeButtonHandler'` to your Podfile.


### PR DESCRIPTION
This PR adds support for installation via SPM (Swift Package Manager) by adding a `Package.swift` and a required `include` directory with a symlink to the header file.

I set the minimum swift tools version to 5.4 and minimum iOS target to version 11.0. But feel free change either of those (though iOS 11 is the minimum possible AFAIK).